### PR TITLE
Fixed Unhandled 'error' event (Issue #7)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -63,14 +63,13 @@ gulp.task('images', function buildImages() {
  */
 gulp.task('html', gulp.series('styles', function buildHtml() {
   const pageFilter = filter(['**/pages/*.html']);
-
   return gulp.src(paths.html.src)
     .pipe(pageFilter)
     .pipe(fileinclude({
       prefix: '%%',
       basepath: '@file'
     }))
-    .pipe(autoScript)
+    .pipe(autoScript())
     .pipe(gulp.dest(paths.html.dest));
 }));
 
@@ -124,10 +123,11 @@ gulp.task('serve', function sync(done) {
  * Sets up live-reloading: Changes to HTML or CSS trigger a rebuild, changes to
  * images only result in images being copied again to dist.
  */
-gulp.task('watch', function watch() {
+gulp.task('watch', function watch(done) {
   gulp.watch(paths.images.src, gulp.series('images'));
   gulp.watch('src/html/**/*.html', gulp.series('rebuild'));
   gulp.watch(paths.css.src, gulp.series('rebuild'));
+  done();
 });
 
 /**
@@ -139,5 +139,4 @@ gulp.task('prepare', gulp.series('clean', 'build'));
  * Default task is to perform a clean build then set up browser sync for live
  * reloading.
  */
-gulp.task('default', gulp.series('clean', 'build',
-  gulp.parallel('serve', 'watch')));
+gulp.task('default', gulp.series('clean', 'build','serve', 'watch'));

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "author": "Ben Morss",
   "license": "Apache-2.0",
   "dependencies": {
-    "amphtml-autoscript": "^1.1.2",
+    "amphtml-autoscript": "^1.2.0",
     "amphtml-validator": "^1.0.23",
     "browser-sync": "^2.24.5",
     "del": "^3.0.0",
@@ -23,7 +23,7 @@
     "gulp-sass": "*",
     "gulp-sourcemaps": "*",
     "gulp-uglify": "*",
-    "jsdom": "^11.11.0",
+    "jsdom": "^11.12.0",
     "through2": "^2.0.3",
     "uglify-es": "^3.3.10",
     "workbox-build": "*",


### PR DESCRIPTION
Ben,

This fixes the reload issue for me. It was a combination of:

1. A slight omission in the gulpfile, not calling the callback to indicate when the watch task was done.
2. An error in amphtml-autoscript where reuse was causing issues. This was the real culprit!

Testing it locally I am able to make changes to HTML and live reloading works fine.