### PR TITLE
Fixing bugs and adding functionality to product-details.html

### DIFF
--- a/src/html/pages/product-details.html
+++ b/src/html/pages/product-details.html
@@ -39,7 +39,7 @@ limitations under the License.
             {
                 "price": "${{Price}}",
                 "selectedColor": "{{All_Colors.0.ColorName}}",
-                { {# All_Colors } }
+                {{#All_Colors}}
                 "{{ColorName}}": {
                     "thumb": {
                         "image1": "{{& Photo}}",
@@ -52,11 +52,9 @@ limitations under the License.
                         "image3": "{{& Photo}}"
                     }
                 },
-                {
-                    {
-                        /All_Colors}}  
-                        "selectedSlide": 0
-                    }
+                {{/All_Colors}}
+                "selectedSlide": 0
+            }
             </script>
         </amp-state>
         <section class="flex flex-wrap pb4 md-pb7">

--- a/src/html/pages/product-details.html
+++ b/src/html/pages/product-details.html
@@ -118,9 +118,16 @@ limitations under the License.
                         <ul class="m0 list-reset inline-block">
                             {{#All_Colors}}
                             <li class="inline-block mr1">
-                                <div option="black" selected="selected">
-                                    <amp-img src="{{& Swatch}}" height="16" width="27"></amp-img>
-                                </div>
+                                {{#defaultColour}}
+                                    <div option="black" selected="selected">
+                                        <amp-img src="{{& Swatch}}" height="16" width="27"></amp-img>
+                                    </div>
+                                {{/defaultColour}}
+                                {{^defaultColour}}
+                                    <div option="{{ColorName}}">
+                                        <amp-img src="{{& Swatch}}" height="16" width="27"></amp-img>
+                                    </div>
+                                {{/defaultColour}}
                             </li>
                             {{/All_Colors}}
                         </ul>

--- a/src/html/pages/product-details.html
+++ b/src/html/pages/product-details.html
@@ -59,7 +59,7 @@ limitations under the License.
         </amp-state>
         <section class="flex flex-wrap pb4 md-pb7">
             <div class="col-12 md-col-6 px2 pt2 md-pl7 md-pt4">
-                <amp-carousel width="1280" height="720" layout="responsive" type="slides" [slide]="product.selectedSlide" on="slideChange: AMP.setState({product: {selectedSlide: event.index}})">
+                <amp-carousel width="1280" height="720" layout="responsive" type="slides" [slide]="product.selectedSlide" on="slideChange: AMP.setState({product: {selectedSlide: event.index}})">                    
                     <amp-img [src]="product[product.selectedColor].large.image1" src="{{& All_Colors.0.Photo}}" width="1280" height="720" layout="responsive" role="button" tabindex="0" alt="product image" noloading="">
                         <div placeholder="" class="commerce-loader"></div>
                     </amp-img>
@@ -119,7 +119,7 @@ limitations under the License.
                             {{#All_Colors}}
                             <li class="inline-block mr1">
                                 {{#defaultColour}}
-                                    <div option="black" selected="selected">
+                                    <div option="{{ColorName}}" selected="selected">
                                         <amp-img src="{{& Swatch}}" height="16" width="27"></amp-img>
                                     </div>
                                 {{/defaultColour}}

--- a/src/html/pages/product-details.html
+++ b/src/html/pages/product-details.html
@@ -65,13 +65,16 @@ limitations under the License.
                     <amp-img [src]="product[product.selectedColor].large.image1" src="{{& All_Colors.0.Photo}}" width="1280" height="720" layout="responsive" role="button" tabindex="0" alt="product image" noloading="">
                         <div placeholder="" class="commerce-loader"></div>
                     </amp-img>
+                    <!--
                     <amp-img [src]="product[product.selectedColor].large.image2" src="{{& All_Colors.0.Photo}}" width="1280" height="720" layout="responsive" role="button" tabindex="0" alt="product image" noloading="">
                         <div placeholder="" class="commerce-loader"></div>
                     </amp-img>
                     <amp-img [src]="product[product.selectedColor].large.image3" src="{{& All_Colors.0.Photo}}" width="1280" height="720" layout="responsive" role="button" tabindex="0" alt="product image" noloading="">
                         <div placeholder="" class="commerce-loader"></div>
                     </amp-img>
+                -->
                 </amp-carousel>
+                <!--
                 <amp-selector class="center" [selected]="product.selectedSlide" on="select:AMP.setState({product: {selectedSlide: event.targetOption}})">
                     <ul class="list-reset inline-block">
                         <li class="inline-block commerce-product-thumb">
@@ -85,6 +88,7 @@ limitations under the License.
                         </li>
                     </ul>
                 </amp-selector>
+            -->
             </div>
             <div class="col-12 md-col-6 flex flex-wrap content-start px2 md-pl5 md-pr7 md-pt4">
                 <div class="col-6 self-start pb2">

--- a/src/server/ApiManager.js
+++ b/src/server/ApiManager.js
@@ -74,7 +74,10 @@ class ApiManager {
         productObj.ReviewFullStars = reviewFullStars;
         productObj.ReviewEmptyStars = reviewEmptyStars;
         productObj.ReviewCount = productObj.ReviewCount || 0;
-        
+
+        //mark first color as 'selected', so mustache can render selector appropriately in product-details template.
+        productObj.All_Colors[0].defaultColour = true;
+
         return productObj;
     }
 

--- a/src/server/ApiManager.js
+++ b/src/server/ApiManager.js
@@ -44,6 +44,7 @@ class ApiManager {
             parsedProd.price = originalProd.Price;
             parsedProd.image = originalProd.Photo;
             parsedProd.category = originalProd.Main_Id; /* Missing field on Campmor API */
+            productObj.ReviewCount = productObj.ReviewCount || 0;
 
             parsedCategory.items.push(parsedProd);
         }

--- a/src/server/ApiManager.js
+++ b/src/server/ApiManager.js
@@ -44,7 +44,6 @@ class ApiManager {
             parsedProd.price = originalProd.Price;
             parsedProd.image = originalProd.Photo;
             parsedProd.category = originalProd.Main_Id; /* Missing field on Campmor API */
-            productObj.ReviewCount = productObj.ReviewCount || 0;
 
             parsedCategory.items.push(parsedProd);
         }
@@ -74,6 +73,8 @@ class ApiManager {
         }
         productObj.ReviewFullStars = reviewFullStars;
         productObj.ReviewEmptyStars = reviewEmptyStars;
+        productObj.ReviewCount = productObj.ReviewCount || 0;
+        
         return productObj;
     }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -62,7 +62,6 @@ app.get('/api/categories', function(req, res) {
 
     request(options, (error, response, body) => {
         if (!error) {
-            apiManager.parseProduct(body);
             res.send(apiManager.parseCategory(body));
         } else {
             res.json({ error: 'An error occurred in /api/categories' });


### PR DESCRIPTION
- Limited product image carousel to one element, since the API doesn't have multiple images per product color.
- "Reviews" field show "0" when "ReviewCount" field is null.
- Fixed bug on amp-state (JSON was invalid).
- Developed amp-bind functionality for product color.
- Fixed bug on server.js: was unnecessarily calling "parseProduct" inside a call to category API.