### PR TITLE
Running server automatically after build takes place. Integrating browsersync with server.js.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "workbox-sw": "*"
   },
   "devDependencies": {
-    "gulp": "github:gulpjs/gulp#4.0"
+    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp-nodemon": "^2.2.1"
   }
 }


### PR DESCRIPTION
Integrated browsersync with the existing server at src/server/server.js.
browsersync will now act as a proxy of the real server, that's listening at localhost:8080.
When a change is made on one of the files, a rebuild might take place, according to the configuration in "watch". This will make browsersync reload the server so these changes take effect.
If a change takes place on server.js, it will cause the nodemon server to reload.